### PR TITLE
liquidBar: show clip toggle only for Canvas and reset clip on AGSL modes

### DIFF
--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/DifferenceBlendModifier.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/DifferenceBlendModifier.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 
-internal fun Modifier.invertByDifferenceBlend(): Modifier = graphicsLayer {
-    compositingStrategy = CompositingStrategy.Offscreen
-    blendMode = BlendMode.Difference
-}
+ internal fun Modifier.invertByDifferenceBlend(): Modifier = graphicsLayer {
+     compositingStrategy = CompositingStrategy.Offscreen
+     blendMode = BlendMode.Difference
+ }
+
+//internal fun Modifier.invertByDifferenceBlend(): Modifier = this

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBarContent.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBarContent.kt
@@ -17,22 +17,24 @@ import androidx.compose.ui.zIndex
 @Composable
 fun LiquidBarContent(
     screenMode: ScreenMode,
+    clipContentByWavePath: Boolean,
     paddingValues: PaddingValues,
     contentText: String,
     modifier: Modifier = Modifier,
 ) {
+    val useCanvasDifference = screenMode == ScreenMode.Canvas && !clipContentByWavePath
+
     Column(
         modifier = modifier
             .fillMaxSize()
             .then(
-                when (screenMode) {
-                    ScreenMode.Canvas -> Modifier
+                if (useCanvasDifference) {
+                    Modifier
                         .zIndex(10f)
                         .invertByDifferenceBlend()
                         .padding(paddingValues)
-
-                    ScreenMode.Agsl,
-                    ScreenMode.AgslCanvas -> Modifier
+                } else {
+                    Modifier
                 }
             )
             .verticalScroll(rememberScrollState())
@@ -40,20 +42,16 @@ fun LiquidBarContent(
         Text(
             modifier = Modifier
                 .then(
-                    when (screenMode) {
-                        ScreenMode.Canvas -> Modifier
-                        ScreenMode.Agsl,
-                        ScreenMode.AgslCanvas -> Modifier.padding(paddingValues)
+                    if (useCanvasDifference) {
+                        Modifier
+                    } else {
+                        Modifier.padding(paddingValues)
                     }
                 )
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             style = MaterialTheme.typography.bodyLarge,
             text = contentText,
-            color = when (screenMode) {
-                ScreenMode.Canvas -> Color.White
-                ScreenMode.Agsl,
-                ScreenMode.AgslCanvas -> Color.Black
-            }
+            color = if (useCanvasDifference) Color.White else Color.Black
         )
     }
 }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBarScreen.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBarScreen.kt
@@ -80,7 +80,7 @@ fun LiquidBarScreen(
             onSelectedIndexChange = { selectedIndex = it },
             screenMode = screenMode,
             renderType = renderType,
-            clipContentByWavePath = clipContentByWavePath,
+            clipContentByWavePath = screenMode == ScreenMode.Canvas && clipContentByWavePath,
             liquidContainerHeight = liquidContainerHeight,
             navBarHeight = navBarHeight,
             bottomInset = bottomInset
@@ -92,14 +92,19 @@ fun LiquidBarScreen(
                 .align(Alignment.TopCenter),
             screenMode = screenMode,
             renderType = renderType,
-            clipContentByWavePath = clipContentByWavePath,
+            clipContentByWavePath = screenMode == ScreenMode.Canvas && clipContentByWavePath,
             topLiquidContainerHeight = topLiquidContainerHeight,
             topBarHitHeight = topBarHitHeight,
             topInset = topInset,
             onePixelDp = onePixelDp,
             topSwitchRowHeight = topSwitchRowHeight,
             onNavUp = { navBackStack.navigateUp() },
-            onModeSelected = { screenMode = it },
+            onModeSelected = {
+                screenMode = it
+                if (it != ScreenMode.Canvas) {
+                    clipContentByWavePath = false
+                }
+            },
             onClipToggle = { clipContentByWavePath = !clipContentByWavePath }
         )
     }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBarScreen.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBarScreen.kt
@@ -41,6 +41,7 @@ fun LiquidBarScreen(
     val destinations = rememberLiquidBarDestinations()
     var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
     var screenMode by rememberSaveable { mutableStateOf(ScreenMode.Canvas) }
+    var clipContentByWavePath by rememberSaveable { mutableStateOf(false) }
     val renderType = screenMode.toRenderType()
     val baseText = stringResource(R.string.very_long_mock_text).trimIndent()
     val contentText = "$baseText\n\n$baseText"
@@ -64,6 +65,7 @@ fun LiquidBarScreen(
     ) {
         LiquidBarContent(
             screenMode = screenMode,
+            clipContentByWavePath = clipContentByWavePath,
             paddingValues = contentPadding,
             contentText = contentText,
             modifier = Modifier
@@ -78,6 +80,7 @@ fun LiquidBarScreen(
             onSelectedIndexChange = { selectedIndex = it },
             screenMode = screenMode,
             renderType = renderType,
+            clipContentByWavePath = clipContentByWavePath,
             liquidContainerHeight = liquidContainerHeight,
             navBarHeight = navBarHeight,
             bottomInset = bottomInset
@@ -89,13 +92,15 @@ fun LiquidBarScreen(
                 .align(Alignment.TopCenter),
             screenMode = screenMode,
             renderType = renderType,
+            clipContentByWavePath = clipContentByWavePath,
             topLiquidContainerHeight = topLiquidContainerHeight,
             topBarHitHeight = topBarHitHeight,
             topInset = topInset,
             onePixelDp = onePixelDp,
             topSwitchRowHeight = topSwitchRowHeight,
             onNavUp = { navBackStack.navigateUp() },
-            onModeSelected = { screenMode = it }
+            onModeSelected = { screenMode = it },
+            onClipToggle = { clipContentByWavePath = !clipContentByWavePath }
         )
     }
 }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBottomBar.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidBottomBar.kt
@@ -36,6 +36,7 @@ internal fun LiquidBottomBar(
     onSelectedIndexChange: (Int) -> Unit,
     screenMode: ScreenMode,
     renderType: RenderType,
+    clipContentByWavePath: Boolean,
     liquidContainerHeight: Dp,
     navBarHeight: Dp,
     bottomInset: Dp,
@@ -49,38 +50,40 @@ internal fun LiquidBottomBar(
         bg = Color.Transparent,
         plotWidth = 0f,
         renderType = renderType,
+        clipContentByWavePath = clipContentByWavePath,
         waveColor = Color.Black,
         hitHeight = navBarHeight + bottomInset,
         interactiveContentPosition = InteractiveContentPosition.Bottom,
     ) {
+        val useCanvasDifference = screenMode == ScreenMode.Canvas && !clipContentByWavePath
+
         NavigationBar(
             containerColor = Color.Transparent
         ) {
             destinations.forEachIndexed { index, destination ->
                 val isSelected = selectedIndex == index
-                val isCanvasMode = screenMode == ScreenMode.Canvas
                 val interactionSource = remember { MutableInteractionSource() }
                 val onClick = remember(index, onSelectedIndexChange) {
                     { onSelectedIndexChange(index) }
                 }
                 val isPressed by interactionSource.collectIsPressedAsState()
                 val pressedBgAlpha by animateFloatAsState(
-                    targetValue = if (!isCanvasMode && isPressed) 0.15f else 0f,
+                    targetValue = if (!useCanvasDifference && isPressed) 0.15f else 0f,
                     animationSpec = tween(durationMillis = 180),
                     label = "BottomBarPressedBgAlpha"
                 )
                 val pressedBorderAlpha by animateFloatAsState(
-                    targetValue = if (!isCanvasMode && isPressed) 1f else 0f,
+                    targetValue = if (!useCanvasDifference && isPressed) 1f else 0f,
                     animationSpec = tween(durationMillis = 180),
                     label = "BottomBarPressedBorderAlpha"
                 )
                 val itemColor = if (isSelected) Color.Red else Color.White
-                val itemModifier = if (isCanvasMode && !isSelected) {
+                val itemModifier = if (useCanvasDifference && !isSelected) {
                     Modifier.invertByDifferenceBlend()
                 } else {
                     Modifier
                 }
-                val navItemModifier = if (!isCanvasMode) {
+                val navItemModifier = if (!useCanvasDifference) {
                     Modifier
                         .background(
                             color = Color.White.copy(alpha = pressedBgAlpha),

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidTopBar.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidTopBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ContentCut
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -40,6 +41,7 @@ import com.skul.yuriy.composeplayground.feature.liquidBar.liquid.RenderType
 internal fun LiquidTopBar(
     screenMode: ScreenMode,
     renderType: RenderType,
+    clipContentByWavePath: Boolean,
     topLiquidContainerHeight: Dp,
     topBarHitHeight: Dp,
     topInset: Dp,
@@ -47,8 +49,11 @@ internal fun LiquidTopBar(
     topSwitchRowHeight: Dp,
     onNavUp: () -> Unit,
     onModeSelected: (ScreenMode) -> Unit,
+    onClipToggle: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val useCanvasDifference = screenMode == ScreenMode.Canvas && !clipContentByWavePath
+
     LiquidBox(
         modifier = modifier
             .fillMaxWidth()
@@ -58,13 +63,14 @@ internal fun LiquidTopBar(
         plotWidth = 0f,
         bg = Color.Transparent,
         renderType = renderType,
+        clipContentByWavePath = clipContentByWavePath,
         hitHeight = topBarHitHeight,
         interactiveContentPosition = InteractiveContentPosition.Top,
     ) {
-        val topBarContentModifier = when (screenMode) {
-            ScreenMode.Canvas -> Modifier.invertByDifferenceBlend()
-            ScreenMode.Agsl -> Modifier
-            ScreenMode.AgslCanvas -> Modifier
+        val topBarContentModifier = if (useCanvasDifference) {
+            Modifier.invertByDifferenceBlend()
+        } else {
+            Modifier
         }
 
         Column(
@@ -96,6 +102,19 @@ internal fun LiquidTopBar(
                             modifier = topBarContentModifier
                         )
                     }
+                },
+                actions = {
+                    IconButton(onClick = onClipToggle) {
+                        Icon(
+                            imageVector = Icons.Filled.ContentCut,
+                            contentDescription = if (clipContentByWavePath) {
+                                stringResource(R.string.clip_wave_on)
+                            } else {
+                                stringResource(R.string.clip_wave_off)
+                            },
+                            tint = if (clipContentByWavePath) Color.Red else Color.Gray
+                        )
+                    }
                 }
             )
             Box(
@@ -107,7 +126,7 @@ internal fun LiquidTopBar(
             RenderTypeSwitch(
                 selectedMode = screenMode,
                 onModeSelected = onModeSelected,
-                applyDifference = screenMode == ScreenMode.Canvas,
+                applyDifference = useCanvasDifference,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(topSwitchRowHeight)

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidTopBar.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/LiquidTopBar.kt
@@ -1,5 +1,6 @@
 package com.skul.yuriy.composeplayground.feature.liquidBar
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -104,16 +105,18 @@ internal fun LiquidTopBar(
                     }
                 },
                 actions = {
-                    IconButton(onClick = onClipToggle) {
-                        Icon(
-                            imageVector = Icons.Filled.ContentCut,
-                            contentDescription = if (clipContentByWavePath) {
-                                stringResource(R.string.clip_wave_on)
-                            } else {
-                                stringResource(R.string.clip_wave_off)
-                            },
-                            tint = if (clipContentByWavePath) Color.Red else Color.Gray
-                        )
+                    AnimatedVisibility(visible = screenMode == ScreenMode.Canvas) {
+                        IconButton(onClick = onClipToggle) {
+                            Icon(
+                                imageVector = Icons.Filled.ContentCut,
+                                contentDescription = if (clipContentByWavePath) {
+                                    stringResource(R.string.clip_wave_on)
+                                } else {
+                                    stringResource(R.string.clip_wave_off)
+                                },
+                                tint = if (clipContentByWavePath) Color.Red else Color.Gray
+                            )
+                        }
                     }
                 }
             )

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/LiquidBox.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/LiquidBox.kt
@@ -174,7 +174,6 @@ fun LiquidBox(
                     scale = scale,
                     yGain = yGain,
                     sim = sim,
-                    bg = bg
                 )
             }
         }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/LiquidBox.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/LiquidBox.kt
@@ -124,7 +124,7 @@ fun LiquidBox(
                 plotWidth = plotWidth,
                 scale = scale,
                 yGain = yGain,
-                sampleWave = { xNorm -> sim.sampleCurr(xNorm) }
+                sim = sim,
             )
         }
 
@@ -161,7 +161,7 @@ fun LiquidBox(
                         plotWidth = plotWidth,
                         scale = scale,
                         yGain = yGain,
-                        sampleWave = { xNorm -> sim.sampleCurr(xNorm) }
+                        sim = sim,
                     )
                 }
             } else {

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/LiquidBox.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/LiquidBox.kt
@@ -17,15 +17,18 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import com.skul.yuriy.composeplayground.feature.liquidBar.liquid.agsl.liquidWaveCanvasShader
 import com.skul.yuriy.composeplayground.feature.liquidBar.liquid.agsl.rememberLiquidWaveRenderEffectOrNull
+import com.skul.yuriy.composeplayground.feature.liquidBar.liquid.canvas.buildLiquidWavePath
 import com.skul.yuriy.composeplayground.feature.liquidBar.liquid.canvas.drawLiquidWave
 import kotlinx.coroutines.isActive
 
@@ -54,6 +57,7 @@ enum class InteractiveContentPosition {
  * @param waveColor Foreground liquid color.
  * @param dragThrottleMs Min time between touch injections while dragging.
  * @param renderType Render pipeline mode.
+ * @param clipContentByWavePath If true, content is clipped by wave path in Canvas rendering mode.
  * @param hitHeight Interactive zone height. If null, full container is interactive.
  * @param interactiveContentPosition Interactive zone position inside container.
  * @param content Bottom-zone content (typically navigation bar items).
@@ -74,6 +78,7 @@ fun LiquidBox(
     waveColor: Color = Color.White,
     dragThrottleMs: Long = 12L, // inject at most ~83 Hz while dragging
     renderType: RenderType = RenderType.CANVAS,
+    clipContentByWavePath: Boolean = false,
     hitHeight: Dp? = null,
     interactiveContentPosition: InteractiveContentPosition = InteractiveContentPosition.Bottom,
     content: @Composable () -> Unit
@@ -114,18 +119,45 @@ fun LiquidBox(
     var hitZoneSize by remember { mutableStateOf(IntSize.Zero) }
 
     val renderModifier = when (renderType) {
-        RenderType.CANVAS -> Modifier.drawBehind {
-            drawLiquidWave(
-                frameTick = frameTick,
-                containerSize = containerSize,
-                interactiveContentPosition = interactiveContentPosition,
-                bg = bg,
-                waveColor = waveColor,
-                plotWidth = plotWidth,
-                scale = scale,
-                yGain = yGain,
-                sim = sim,
-            )
+        RenderType.CANVAS -> {
+            if (clipContentByWavePath) {
+                Modifier.drawWithContent {
+                    if (frameTick < 0) return@drawWithContent
+                    if (bg.alpha > 0f) {
+                        drawRect(bg)
+                    }
+                    val wavePath = buildLiquidWavePath(
+                        containerSize = containerSize,
+                        interactiveContentPosition = interactiveContentPosition,
+                        plotWidth = plotWidth,
+                        scale = scale,
+                        yGain = yGain,
+                        sim = sim
+                    )
+                    if (wavePath != null) {
+                        drawPath(path = wavePath, color = waveColor)
+                        clipPath(wavePath) {
+                            this@drawWithContent.drawContent()
+                        }
+                    } else {
+                        drawContent()
+                    }
+                }
+            } else {
+                Modifier.drawBehind {
+                    drawLiquidWave(
+                        frameTick = frameTick,
+                        containerSize = containerSize,
+                        interactiveContentPosition = interactiveContentPosition,
+                        bg = bg,
+                        waveColor = waveColor,
+                        plotWidth = plotWidth,
+                        scale = scale,
+                        yGain = yGain,
+                        sim = sim,
+                    )
+                }
+            }
         }
 
         RenderType.AGSL -> {
@@ -151,18 +183,43 @@ fun LiquidBox(
 
         RenderType.AGSL_CANVAS -> {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                Modifier.drawBehind {
-                    drawLiquidWave(
-                        frameTick = frameTick,
-                        containerSize = containerSize,
-                        interactiveContentPosition = interactiveContentPosition,
-                        bg = bg,
-                        waveColor = waveColor,
-                        plotWidth = plotWidth,
-                        scale = scale,
-                        yGain = yGain,
-                        sim = sim,
-                    )
+                if (clipContentByWavePath) {
+                    Modifier.drawWithContent {
+                        if (frameTick < 0) return@drawWithContent
+                        if (bg.alpha > 0f) {
+                            drawRect(bg)
+                        }
+                        val wavePath = buildLiquidWavePath(
+                            containerSize = containerSize,
+                            interactiveContentPosition = interactiveContentPosition,
+                            plotWidth = plotWidth,
+                            scale = scale,
+                            yGain = yGain,
+                            sim = sim
+                        )
+                        if (wavePath != null) {
+                            drawPath(path = wavePath, color = waveColor)
+                            clipPath(wavePath) {
+                                this@drawWithContent.drawContent()
+                            }
+                        } else {
+                            drawContent()
+                        }
+                    }
+                } else {
+                    Modifier.drawBehind {
+                        drawLiquidWave(
+                            frameTick = frameTick,
+                            containerSize = containerSize,
+                            interactiveContentPosition = interactiveContentPosition,
+                            bg = bg,
+                            waveColor = waveColor,
+                            plotWidth = plotWidth,
+                            scale = scale,
+                            yGain = yGain,
+                            sim = sim,
+                        )
+                    }
                 }
             } else {
                 Modifier.liquidWaveCanvasShader(

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/agsl/LiquidWaveCanvasShaderModifier.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/agsl/LiquidWaveCanvasShaderModifier.kt
@@ -8,7 +8,7 @@ import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
@@ -77,7 +77,6 @@ internal fun Modifier.liquidWaveCanvasShader(
     scale: Float,
     yGain: Float,
     sim: Wave1D,
-    bg: Color,
 ): Modifier {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return this
 
@@ -101,47 +100,37 @@ internal fun Modifier.liquidWaveCanvasShader(
     val runtimeShader = remember { RuntimeShader(LiquidWaveCanvasAglsl) }
     val shaderPaint = remember { Paint() }
 
-    profileBitmap.setPixels(waveProfileArgb, 0, profileWidth, 0, 0, profileWidth, 1)
     val profileShader = remember(profileBitmap) {
         BitmapShader(profileBitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
     }
 
-    runtimeShader.setInputShader("waveProfile", profileShader)
-    runtimeShader.setFloatUniform("uContainerWidthPx", width.toFloat())
-    runtimeShader.setFloatUniform("uProfileWidthPx", profileWidth.toFloat())
-    runtimeShader.setFloatUniform("uContainerHeightPx", height.toFloat())
-    runtimeShader.setFloatUniform("uBandPx", bandPx)
-    runtimeShader.setFloatUniform(
-        "uIsTop",
-        if (interactiveContentPosition == InteractiveContentPosition.Top) 1f else 0f
-    )
-    runtimeShader.setFloatUniform(
-        "uWaveColor",
-        waveColor.red,
-        waveColor.green,
-        waveColor.blue,
-        waveColor.alpha
-    )
+    return this.then(
+        Modifier.drawWithCache {
+            shaderPaint.shader = runtimeShader
+            runtimeShader.setInputShader("waveProfile", profileShader)
+            runtimeShader.setFloatUniform("uContainerWidthPx", width.toFloat())
+            runtimeShader.setFloatUniform("uProfileWidthPx", profileWidth.toFloat())
+            runtimeShader.setFloatUniform("uContainerHeightPx", height.toFloat())
+            runtimeShader.setFloatUniform("uBandPx", bandPx)
+            runtimeShader.setFloatUniform(
+                "uIsTop",
+                if (interactiveContentPosition == InteractiveContentPosition.Top) 1f else 0f
+            )
+            runtimeShader.setFloatUniform(
+                "uWaveColor",
+                waveColor.red,
+                waveColor.green,
+                waveColor.blue,
+                waveColor.alpha
+            )
 
-    shaderPaint.shader = runtimeShader
-
-    val drawModifier = remember(
-        runtimeShader,
-        shaderPaint,
-        frameTick,
-        width,
-        height,
-        profileWidth,
-        bandPx,
-        waveColor,
-        bg
-    ) {
-        Modifier.drawBehind {
-            if (frameTick < 0) return@drawBehind
-            drawIntoCanvas { canvas ->
-                canvas.nativeCanvas.drawRect(0f, 0f, size.width, size.height, shaderPaint)
+            onDrawBehind {
+                if (frameTick < 0) return@onDrawBehind
+                profileBitmap.setPixels(waveProfileArgb, 0, profileWidth, 0, 0, profileWidth, 1)
+                drawIntoCanvas { canvas ->
+                    canvas.nativeCanvas.drawRect(0f, 0f, size.width, size.height, shaderPaint)
+                }
             }
         }
-    }
-    return this.then(drawModifier)
+    )
 }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/canvas/LiquidWaveDraw.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/canvas/LiquidWaveDraw.kt
@@ -1,11 +1,12 @@
 package com.skul.yuriy.composeplayground.feature.liquidBar.liquid.canvas
 
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.IntSize
 import com.skul.yuriy.composeplayground.feature.liquidBar.liquid.InteractiveContentPosition
+import com.skul.yuriy.composeplayground.feature.liquidBar.liquid.Wave1D
 import kotlin.math.max
 
 internal fun DrawScope.drawLiquidWave(
@@ -17,7 +18,7 @@ internal fun DrawScope.drawLiquidWave(
     plotWidth: Float,
     scale: Float,
     yGain: Float,
-    sampleWave: (Float) -> Float,
+    sim: Wave1D,
 ) {
     if (frameTick < 0) return
 
@@ -34,88 +35,54 @@ internal fun DrawScope.drawLiquidWave(
         drawRect(bg)
     }
 
-    // Convert plotWidth in "scaled space" into pixels.
-    val bandPx = (plotWidth / scale) * hf
+    // Keep signature stable while hard-cut mode is active.
+    plotWidth
 
-    // Work reduction on big widths.
-    val stepPx = max(1, w / 700)
-
-    var xPx = 0
-    while (xPx < w) {
-        val xNorm = xPx / wf
-
-        // Sim value is in arbitrary units; scale it to match uv*=scale space.
-        val yScaled = sampleWave(xNorm) * yGain
-
-        // Wave model is bottom-up; Compose is top-down, so invert:
-        // yPx = (0.5 - y/scale) * h
+    val pointsCount = max(2, sim.n.coerceIn(2, 700))
+    val curvePoints = ArrayList<Offset>(pointsCount)
+    for (i in 0 until pointsCount) {
+        val xPx = (i.toFloat() / (pointsCount - 1).toFloat()) * wf
+        // Wave model is bottom-up; Compose is top-down.
+        val yScaled = sim.sampleCurrAt(i) * yGain
         val yCurvePx = (0.5f - (yScaled / scale)) * hf
-
-        val yMid = yCurvePx.coerceIn(0f, hf)
-        if (isTopInteractive) {
-            val yBottom = (yMid + bandPx).coerceIn(0f, hf)
-
-            // Soft edge for top-anchored wave (fade downwards).
-            if (bandPx > 0.5f) {
-                val slices = 6
-                for (s in 0 until slices) {
-                    val t = s.toFloat() / (slices - 1).toFloat()
-                    val alpha = 1f - t
-                    val y0 = yMid + t * (yBottom - yMid)
-                    val y1 = yMid + (t + 1f / slices) * (yBottom - yMid)
-                    drawRect(
-                        color = waveColor.copy(alpha = alpha.coerceIn(0f, 1f)),
-                        topLeft = Offset(xPx.toFloat(), y0),
-                        size = Size(
-                            stepPx.toFloat(),
-                            (y1 - y0).coerceAtLeast(1f)
-                        )
-                    )
-                }
-            }
-
-            // Solid fill above curve.
-            drawRect(
-                color = waveColor,
-                topLeft = Offset(xPx.toFloat(), 0f),
-                size = Size(
-                    stepPx.toFloat(),
-                    yMid.coerceAtLeast(0f)
-                )
-            )
-        } else {
-            val yTop = (yMid - bandPx).coerceIn(0f, hf)
-
-            // Soft edge approximation (smoothstep band)
-            if (bandPx > 0.5f) {
-                val slices = 6
-                for (s in 0 until slices) {
-                    val t = s.toFloat() / (slices - 1).toFloat()
-                    val alpha = 1f - t
-                    val y0 = yTop + t * (yMid - yTop)
-                    val y1 = yTop + (t + 1f / slices) * (yMid - yTop)
-                    drawRect(
-                        color = waveColor.copy(alpha = alpha.coerceIn(0f, 1f)),
-                        topLeft = Offset(xPx.toFloat(), y0),
-                        size = Size(
-                            stepPx.toFloat(),
-                            (y1 - y0).coerceAtLeast(1f)
-                        )
-                    )
-                }
-            }
-
-            // Solid fill below curve (matches their "plot" feel)
-            drawRect(
-                color = waveColor,
-                topLeft = Offset(xPx.toFloat(), yMid),
-                size = Size(
-                    stepPx.toFloat(),
-                    (hf - yMid).coerceAtLeast(0f)
-                )
-            )
-        }
-
-        xPx += stepPx
+        curvePoints += Offset(xPx, yCurvePx.coerceIn(0f, hf))
     }
+
+    val solidPath = Path()
+    if (isTopInteractive) {
+        solidPath.moveTo(0f, 0f)
+        solidPath.addSmoothedWaveCurve(curvePoints)
+        solidPath.lineTo(wf, 0f)
+        solidPath.close()
+    } else {
+        solidPath.moveTo(0f, hf)
+        solidPath.addSmoothedWaveCurve(curvePoints)
+        solidPath.lineTo(wf, hf)
+        solidPath.close()
+    }
+    drawPath(path = solidPath, color = waveColor)
+}
+
+private fun Path.addSmoothedWaveCurve(points: List<Offset>) {
+    if (points.isEmpty()) return
+    if (points.size == 1) {
+        lineTo(points[0].x, points[0].y)
+        return
+    }
+
+    lineTo(points[0].x, points[0].y)
+    if (points.size == 2) {
+        lineTo(points[1].x, points[1].y)
+        return
+    }
+
+    for (i in 1 until points.lastIndex) {
+        val p = points[i]
+        val next = points[i + 1]
+        val midX = (p.x + next.x) * 0.5f
+        val midY = (p.y + next.y) * 0.5f
+        quadraticTo(p.x, p.y, midX, midY)
+    }
+    val last = points.last()
+    lineTo(last.x, last.y)
 }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/canvas/LiquidWaveDraw.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/canvas/LiquidWaveDraw.kt
@@ -21,19 +21,38 @@ internal fun DrawScope.drawLiquidWave(
     sim: Wave1D,
 ) {
     if (frameTick < 0) return
+    if (bg.alpha > 0f) {
+        drawRect(bg)
+    }
 
+    val wavePath = buildLiquidWavePath(
+        containerSize = containerSize,
+        interactiveContentPosition = interactiveContentPosition,
+        plotWidth = plotWidth,
+        scale = scale,
+        yGain = yGain,
+        sim = sim
+    ) ?: return
+
+    drawPath(path = wavePath, color = waveColor)
+}
+
+internal fun buildLiquidWavePath(
+    containerSize: IntSize,
+    interactiveContentPosition: InteractiveContentPosition,
+    plotWidth: Float,
+    scale: Float,
+    yGain: Float,
+    sim: Wave1D,
+): Path? {
     val isTopInteractive = interactiveContentPosition == InteractiveContentPosition.Top
 
     val w = containerSize.width
     val h = containerSize.height
-    if (w <= 0 || h <= 0) return
+    if (w <= 0 || h <= 0) return null
 
     val wf = w.toFloat()
     val hf = h.toFloat()
-
-    if (bg.alpha > 0f) {
-        drawRect(bg)
-    }
 
     // Keep signature stable while hard-cut mode is active.
     plotWidth
@@ -60,7 +79,7 @@ internal fun DrawScope.drawLiquidWave(
         solidPath.lineTo(wf, hf)
         solidPath.close()
     }
-    drawPath(path = solidPath, color = waveColor)
+    return solidPath
 }
 
 private fun Path.addSmoothedWaveCurve(points: List<Offset>) {

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/canvas/LiquidWaveDraw.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/liquidBar/liquid/canvas/LiquidWaveDraw.kt
@@ -30,7 +30,9 @@ internal fun DrawScope.drawLiquidWave(
     val wf = w.toFloat()
     val hf = h.toFloat()
 
-    drawRect(bg)
+    if (bg.alpha > 0f) {
+        drawRect(bg)
+    }
 
     // Convert plotWidth in "scaled space" into pixels.
     val bandPx = (plotWidth / scale) * hf

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,8 @@
     <string name="render_effect_blur_scaled_glow">RenderEffect Blur + Scaled Glow</string>
     <string name="clipped_default_android_shadow">Clipped Default Android Shadow</string>
     <string name="go_back">Go Back</string>
+    <string name="clip_wave_on">Wave clip enabled</string>
+    <string name="clip_wave_off">Wave clip disabled</string>
     <string name="halo">Halo</string>
     <string name="pressed">Pressed</string>
     <string name="body">Body</string>


### PR DESCRIPTION
PR description:

  - Added AnimatedVisibility for the scissors action so it appears only in Canvas mode.
  - When switching from Canvas to AGSL/A-CNVS, clipContentByWavePath is reset to false.
  - clipContentByWavePath is now passed to bars only when Canvas mode is active, so AGSL paths stay in their default behavior.
