### PR TITLE
 Add Metaball Edge Row feature

### DIFF
--- a/app/src/main/java/com/skul/yuriy/composeplayground/AppRoot.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/AppRoot.kt
@@ -24,6 +24,7 @@ import com.skul.yuriy.composeplayground.feature.customAlphaBlurRadial.CustomBlur
 import com.skul.yuriy.composeplayground.feature.gooey.blurConcept.GooeyBasicScreen
 import com.skul.yuriy.composeplayground.feature.liquidBar.LiquidBarScreen
 import com.skul.yuriy.composeplayground.feature.metaballEdgesAdvanced.MetaballEdgeAdvancedScreen
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.MetaballEdgeHorizontalScrollScreen
 import com.skul.yuriy.composeplayground.feature.metaballEdgesAndText.MetaballEdgeTextScreen
 import com.skul.yuriy.composeplayground.feature.metaballEdgesAndText.textScreen.TextMetaballConceptScreen
 import com.skul.yuriy.composeplayground.feature.metaballBlur.MetaballsScreen
@@ -84,6 +85,7 @@ internal fun AppRoot(
                     entry<Screens.CustomBlur> { CustomBlurScreen() }
                     entry<Screens.CustomBlurRadial> { CustomBlurRadialScreen() }
                     entry<Screens.MetaballEdgeAdvanced> { MetaballEdgeAdvancedScreen() }
+                    entry<Screens.MetaballEdgeHorizontalScroll> { MetaballEdgeHorizontalScrollScreen() }
                     entry<Screens.MetaballBasicTextAndEdge> { MetaballEdgeTextScreen() }
                     entry<Screens.TextMetaballConcept> { TextMetaballConceptScreen() }
                     //todo rename last 4 screens according to feature screen names

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/customAlphaBlur/effects/dynamic/AlphaGaussianBlurByWidth.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/customAlphaBlur/effects/dynamic/AlphaGaussianBlurByWidth.kt
@@ -1,0 +1,222 @@
+package com.skul.yuriy.composeplayground.feature.customAlphaBlur.effects.dynamic
+
+import android.graphics.RenderEffect
+import android.graphics.RuntimeShader
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+
+fun Modifier.alphaGaussianBlurByWidth(
+    leftRadius: Dp,
+    rightRadius: Dp,
+    leftEdgeWidth: Dp,
+    rightEdgeWidth: Dp,
+    color: Color = Color.Black.copy(alpha = 0.99f),
+): Modifier = composed {
+    if (Build.VERSION.SDK_INT < 33) return@composed this
+
+    val density = LocalDensity.current
+    val leftRadiusPx = with(density) { leftRadius.toPx() }
+    val rightRadiusPx = with(density) { rightRadius.toPx() }
+    val leftEdgeWidthPx = with(density) { leftEdgeWidth.toPx() }
+    val rightEdgeWidthPx = with(density) { rightEdgeWidth.toPx() }
+    val thresholdPxFor61Tap = with(density) { 16.dp.toPx() }
+
+    var widthPx by remember { mutableIntStateOf(0) }
+
+    val effect = rememberAlphaGaussianBlurByWidthEffect(
+        leftRadiusPx = leftRadiusPx,
+        rightRadiusPx = rightRadiusPx,
+        widthPx = widthPx,
+        leftEdgeWidthPx = leftEdgeWidthPx,
+        rightEdgeWidthPx = rightEdgeWidthPx,
+        color = color,
+        thresholdPxFor61Tap = thresholdPxFor61Tap,
+    )
+
+    this
+        .onSizeChanged { widthPx = it.width }
+        .graphicsLayer {
+            compositingStrategy = CompositingStrategy.Offscreen
+            effect?.let { renderEffect = it.asComposeRenderEffect() }
+        }
+}
+
+private const val AlphaGaussianBlur17TapByWidthAglsl = """
+uniform shader src;
+uniform float2 uDir;
+uniform float  uLeftRadius;   // px
+uniform float  uRightRadius;  // px
+uniform float  uWidth;        // px
+uniform float  uLeftWidth;    // px
+uniform float  uRightWidth;   // px
+
+float localRadius(float x) {
+    float w = max(1.0, uWidth);
+    float left = max(0.0, uLeftWidth);
+    float right = max(0.0, uRightWidth);
+
+    if (x < left) {
+        float k = clamp(x / max(1.0, left), 0.0, 1.0);
+        return uLeftRadius * (1.0 - k);
+    }
+
+    float rightStart = max(left, w - right);
+    if (x > rightStart) {
+        float k = clamp((x - rightStart) / max(1.0, right), 0.0, 1.0);
+        return uRightRadius * k;
+    }
+
+    return 0.0;
+}
+
+half4 main(float2 p) {
+    float r = localRadius(p.x);
+
+    if (r < 0.5) {
+        return src.eval(p);
+    }
+
+    float sigma = max(0.001, r * 0.57735);
+    float stepPx = max(0.25, r / 8.0);
+
+    float4 sum = float4(0.0);
+    float sumW = 0.0;
+
+    for (int i = -8; i <= 8; i++) {
+        float x = float(i) * stepPx;
+        float w = exp(-(x * x) / (2.0 * sigma * sigma));
+        sum += float4(src.eval(p + uDir * x)) * w;
+        sumW += w;
+    }
+
+    return (sumW > 0.0) ? half4(sum / sumW) : src.eval(p);
+}
+"""
+
+private const val AlphaGaussianBlur61TapByWidthAglsl = """
+uniform shader src;
+uniform float2 uDir;
+uniform float  uLeftRadius;   // px
+uniform float  uRightRadius;  // px
+uniform float  uWidth;        // px
+uniform float  uLeftWidth;    // px
+uniform float  uRightWidth;   // px
+
+float localRadius(float x) {
+    float w = max(1.0, uWidth);
+    float left = max(0.0, uLeftWidth);
+    float right = max(0.0, uRightWidth);
+
+    if (x < left) {
+        float k = clamp(x / max(1.0, left), 0.0, 1.0);
+        return uLeftRadius * (1.0 - k);
+    }
+
+    float rightStart = max(left, w - right);
+    if (x > rightStart) {
+        float k = clamp((x - rightStart) / max(1.0, right), 0.0, 1.0);
+        return uRightRadius * k;
+    }
+
+    return 0.0;
+}
+
+half4 main(float2 p) {
+    float r = localRadius(p.x);
+
+    if (r < 0.5) {
+        return src.eval(p);
+    }
+
+    float sigma = max(0.001, r * 0.57735);
+    float stepPx = max(0.125, r / 30.0);
+
+    float4 sum = float4(0.0);
+    float sumW = 0.0;
+
+    for (int i = -30; i <= 30; i++) {
+        float x = float(i) * stepPx;
+        float w = exp(-(x * x) / (2.0 * sigma * sigma));
+        sum += float4(src.eval(p + uDir * x)) * w;
+        sumW += w;
+    }
+
+    return (sumW > 0.0) ? half4(sum / sumW) : src.eval(p);
+}
+"""
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun rememberAlphaGaussianBlurByWidthEffect(
+    leftRadiusPx: Float,
+    rightRadiusPx: Float,
+    widthPx: Int,
+    leftEdgeWidthPx: Float,
+    rightEdgeWidthPx: Float,
+    color: Color,
+    thresholdPxFor61Tap: Float,
+): RenderEffect? {
+    if (widthPx <= 0) return null
+
+    val resolvedLeftRadiusPx = max(0f, leftRadiusPx)
+    val resolvedRightRadiusPx = max(0f, rightRadiusPx)
+    val contentWidthPx = max(1, widthPx).toFloat()
+    val leftPx = max(0f, leftEdgeWidthPx)
+    val rightPx = max(0f, rightEdgeWidthPx)
+    val maxRadiusPx = max(resolvedLeftRadiusPx, resolvedRightRadiusPx)
+    val use61TapKernel = maxRadiusPx > thresholdPxFor61Tap
+
+    val shaderSource = if (use61TapKernel) {
+        AlphaGaussianBlur61TapByWidthAglsl
+    } else {
+        AlphaGaussianBlur17TapByWidthAglsl
+    }
+
+    return remember(
+        resolvedLeftRadiusPx,
+        resolvedRightRadiusPx,
+        contentWidthPx,
+        leftPx,
+        rightPx,
+        color,
+        use61TapKernel
+    ) {
+        val rtH = RuntimeShader(shaderSource).apply {
+            setFloatUniform("uDir", 1f, 0f)
+            setFloatUniform("uLeftRadius", resolvedLeftRadiusPx)
+            setFloatUniform("uRightRadius", resolvedRightRadiusPx)
+            setFloatUniform("uWidth", contentWidthPx)
+            setFloatUniform("uLeftWidth", leftPx)
+            setFloatUniform("uRightWidth", rightPx)
+        }
+
+        val rtV = RuntimeShader(shaderSource).apply {
+            setFloatUniform("uDir", 0f, 1f)
+            setFloatUniform("uLeftRadius", resolvedLeftRadiusPx)
+            setFloatUniform("uRightRadius", resolvedRightRadiusPx)
+            setFloatUniform("uWidth", contentWidthPx)
+            setFloatUniform("uLeftWidth", leftPx)
+            setFloatUniform("uRightWidth", rightPx)
+        }
+
+        val eH = RenderEffect.createRuntimeShaderEffect(rtH, "src")
+        val eV = RenderEffect.createRuntimeShaderEffect(rtV, "src")
+        RenderEffect.createChainEffect(eV, eH)
+    }
+}

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/customAlphaBlur/effects/dynamic/AlphaGaussianBlurByWidth.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/customAlphaBlur/effects/dynamic/AlphaGaussianBlurByWidth.kt
@@ -52,6 +52,8 @@ fun Modifier.alphaGaussianBlurByWidth(
     this
         .onSizeChanged { widthPx = it.width }
         .graphicsLayer {
+            //without clipping custom AGSL works really wierd
+            clip = true
             compositingStrategy = CompositingStrategy.Offscreen
             effect?.let { renderEffect = it.asComposeRenderEffect() }
         }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollContent.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollContent.kt
@@ -1,0 +1,61 @@
+package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.sections.CircularItemsSection
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.sections.HorizontalTextSection
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.sections.PlainIconsSection
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+fun MetaballEdgeHorizontalScrollContent(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
+) {
+    Column(
+        modifier = modifier
+            .background(Color.White)
+            .padding(contentPadding)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Spacer(modifier = Modifier.height(24.dp))
+        CircularItemsSection()
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 24.dp),
+            thickness = 1.dp,
+            color = Color.Black
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        PlainIconsSection()
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 24.dp),
+            thickness = 1.dp,
+            color = Color.Black
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        HorizontalTextSection()
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = Color.Black
+        )
+    }
+}

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollDemoData.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollDemoData.kt
@@ -1,0 +1,41 @@
+package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.ui.graphics.vector.ImageVector
+
+internal data class CircularItemUiItem(
+    val id: Int,
+    val icon: ImageVector,
+)
+
+private val circularItemIcons = listOf(
+    Icons.Default.Home,
+    Icons.Default.Search,
+    Icons.Default.Person,
+    Icons.Default.Settings,
+    Icons.Default.ShoppingCart,
+    Icons.Default.Info,
+    Icons.Default.Done,
+    Icons.Default.Call,
+    Icons.Default.Build,
+    Icons.Default.Add,
+    Icons.Default.Favorite,
+)
+
+internal val circularItemUiItems = List(16) { index ->
+    CircularItemUiItem(
+        id = index,
+        icon = circularItemIcons[index % circularItemIcons.size],
+    )
+}

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollScreen.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollScreen.kt
@@ -1,0 +1,184 @@
+package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll
+
+import android.graphics.Color as AndroidColor
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.ui.draw.clip
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.skul.yuriy.composeplayground.LocalNavBackStack
+import com.skul.yuriy.composeplayground.R
+import com.skul.yuriy.composeplayground.navigation.navigateUp
+import com.skul.yuriy.composeplayground.util.regularComponents.CustomTopAppBar
+
+@Composable
+fun MetaballEdgeHorizontalScrollScreen(
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val activity = context as? ComponentActivity
+    val navBackStack = LocalNavBackStack.current
+
+    DisposableEffect(activity) {
+        activity?.enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(AndroidColor.BLACK),
+            navigationBarStyle = SystemBarStyle.dark(AndroidColor.BLACK),
+        )
+
+        onDispose {
+            activity?.enableEdgeToEdge(
+                statusBarStyle = SystemBarStyle.dark(AndroidColor.TRANSPARENT),
+                navigationBarStyle = SystemBarStyle.dark(AndroidColor.TRANSPARENT),
+            )
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = Color.White,
+        topBar = {
+            CustomTopAppBar(
+                title = stringResource(R.string.metaball_edge_horizontal_scroll),
+                onNavUp = { navBackStack.navigateUp() },
+                modifier = Modifier.statusBarsPadding(),
+                containerColor = Color.Black,
+                dividerColor = Color.Black,
+            )
+        },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(Color.Black)
+                    .navigationBarsPadding()
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+                .padding(innerPadding)
+        ) {
+            Spacer(modifier = Modifier.height(24.dp))
+            StoriesSection()
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = 1.dp,
+                color = Color.Black
+            )
+        }
+    }
+}
+
+@Composable
+private fun StoriesSection(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(116.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 56.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(
+                items = storyUiItems,
+                key = { it.id }
+            ) { item ->
+                StoryPlaceholder(icon = item.icon)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoryPlaceholder(
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(72.dp)
+            .clip(CircleShape)
+            .background(Color.Black),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(34.dp)
+        )
+    }
+}
+
+private data class StoryUiItem(
+    val id: Int,
+    val icon: ImageVector,
+)
+
+private val storyIcons = listOf(
+    Icons.Default.Add,
+    Icons.Default.Home,
+    Icons.Default.Search,
+    Icons.Default.Person,
+    Icons.Default.Settings,
+    Icons.Default.ShoppingCart,
+    Icons.Default.Favorite,
+    Icons.Default.Info,
+    Icons.Default.Done,
+    Icons.Default.Call,
+    Icons.Default.Build,
+)
+
+private val storyUiItems = List(20) { index ->
+    StoryUiItem(
+        id = index,
+        icon = storyIcons[index % storyIcons.size],
+    )
+}

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollScreen.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballEdgeHorizontalScrollScreen.kt
@@ -1,47 +1,25 @@
 package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll
 
 import android.graphics.Color as AndroidColor
+import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Build
-import androidx.compose.material.icons.filled.Call
-import androidx.compose.material.icons.filled.Done
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.ShoppingCart
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.ui.draw.clip
+import androidx.compose.material3.Text
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -94,91 +72,24 @@ fun MetaballEdgeHorizontalScrollScreen(
             )
         },
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.White)
-                .padding(innerPadding)
-        ) {
-            Spacer(modifier = Modifier.height(24.dp))
-            StoriesSection()
-            HorizontalDivider(
-                modifier = Modifier.fillMaxWidth(),
-                thickness = 1.dp,
-                color = Color.Black
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            MetaballEdgeHorizontalScrollContent(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = innerPadding,
             )
-        }
-    }
-}
-
-@Composable
-private fun StoriesSection(
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(116.dp),
-        contentAlignment = Alignment.CenterStart
-    ) {
-        LazyRow(
-            modifier = Modifier.fillMaxWidth(),
-            contentPadding = PaddingValues(horizontal = 56.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            items(
-                items = storyUiItems,
-                key = { it.id }
-            ) { item ->
-                StoryPlaceholder(icon = item.icon)
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .background(Color.White),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Requires Android 13+ (API 33) for AGSL",
+                    color = Color.Black,
+                )
             }
         }
     }
-}
-
-@Composable
-private fun StoryPlaceholder(
-    icon: ImageVector,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .size(72.dp)
-            .clip(CircleShape)
-            .background(Color.Black),
-        contentAlignment = Alignment.Center
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = Color.White,
-            modifier = Modifier.size(34.dp)
-        )
-    }
-}
-
-private data class StoryUiItem(
-    val id: Int,
-    val icon: ImageVector,
-)
-
-private val storyIcons = listOf(
-    Icons.Default.Add,
-    Icons.Default.Home,
-    Icons.Default.Search,
-    Icons.Default.Person,
-    Icons.Default.Settings,
-    Icons.Default.ShoppingCart,
-    Icons.Default.Favorite,
-    Icons.Default.Info,
-    Icons.Default.Done,
-    Icons.Default.Call,
-    Icons.Default.Build,
-)
-
-private val storyUiItems = List(20) { index ->
-    StoryUiItem(
-        id = index,
-        icon = storyIcons[index % storyIcons.size],
-    )
 }

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballHorizontalEdgeSection.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/MetaballHorizontalEdgeSection.kt
@@ -1,0 +1,136 @@
+package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.RenderEffect as ComposeRenderEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.skul.yuriy.composeplayground.feature.customAlphaBlur.effects.dynamic.alphaGaussianBlurByWidth
+import com.skul.yuriy.composeplayground.util.renderEffect.alphaThreshold50PercentEffect
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+fun MetaballHorizontalEdgeSection(
+    modifier: Modifier = Modifier,
+    sectionHeight: Dp = 116.dp,
+    effectMagnitude: Dp = 56.dp,
+    blurRadius: Dp = 30.dp,
+    contentHorizontalPadding: Dp = 16.dp,
+    itemSpacing: Dp = 16.dp,
+    alphaThresholdEffect: ComposeRenderEffect? = alphaThreshold50PercentEffect,
+    edgeAlpha: Float = 0.5f,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val isAtStart by remember(scrollState) {
+        derivedStateOf { scrollState.value == 0 }
+    }
+    val isAtEnd by remember(scrollState) {
+        derivedStateOf { scrollState.value == scrollState.maxValue }
+    }
+    val leftBlurRadius by animateDpAsState(
+        targetValue = if (isAtStart) 0.dp else blurRadius,
+        animationSpec = tween(durationMillis = 600),
+        label = "left-metaball-edge-blur"
+    )
+    val rightBlurRadius by animateDpAsState(
+        targetValue = if (isAtEnd) 0.dp else blurRadius,
+        animationSpec = tween(durationMillis = 600),
+        label = "right-metaball-edge-blur"
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(sectionHeight)
+            .graphicsLayer {
+                compositingStrategy = CompositingStrategy.Offscreen
+                renderEffect = alphaThresholdEffect
+            },
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Row(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .alphaGaussianBlurByWidth(
+                    leftRadius = leftBlurRadius,
+                    rightRadius = rightBlurRadius,
+                    leftEdgeWidth = effectMagnitude,
+                    rightEdgeWidth = effectMagnitude,
+                )
+                .horizontalScroll(scrollState)
+                .padding(horizontal = contentHorizontalPadding),
+            horizontalArrangement = Arrangement.spacedBy(itemSpacing),
+            content = content
+        )
+
+        MetaballHorizontalGradientEdges(
+            sectionHeight = sectionHeight,
+            effectMagnitude = effectMagnitude,
+            edgeAlpha = edgeAlpha,
+        )
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun BoxScope.MetaballHorizontalGradientEdges(
+    sectionHeight: Dp,
+    effectMagnitude: Dp,
+    edgeAlpha: Float,
+) {
+    Box(
+        modifier = Modifier
+            .align(Alignment.CenterStart)
+            .fillMaxHeight()
+            .size(width = effectMagnitude, height = sectionHeight)
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        Color.Black.copy(alpha = edgeAlpha),
+                        Color.Black.copy(alpha = 0f),
+                    )
+                )
+            )
+    )
+
+    Box(
+        modifier = Modifier
+            .align(Alignment.CenterEnd)
+            .fillMaxHeight()
+            .size(width = effectMagnitude, height = sectionHeight)
+            .background(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        Color.Black.copy(alpha = 0f),
+                        Color.Black.copy(alpha = edgeAlpha),
+                    )
+                )
+            )
+    )
+}

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/sections/CircularItemsSection.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/sections/CircularItemsSection.kt
@@ -1,0 +1,64 @@
+package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.sections
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.circularItemUiItems
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.MetaballHorizontalEdgeSection
+import com.skul.yuriy.composeplayground.util.renderEffect.alphaThreshold50PercentEffect
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+fun CircularItemsSection(
+    modifier: Modifier = Modifier,
+) {
+    val effectMagnitude = 56.dp
+    val blurRadius = 20.dp
+    val alphaThresholdEffect = alphaThreshold50PercentEffect
+    val edgeAlpha = 0.5f
+
+    MetaballHorizontalEdgeSection(
+        modifier = modifier,
+        effectMagnitude = effectMagnitude,
+        blurRadius = blurRadius,
+        alphaThresholdEffect = alphaThresholdEffect,
+        edgeAlpha = edgeAlpha,
+    ) {
+        circularItemUiItems.forEach { item ->
+            CircularItem(icon = item.icon)
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun CircularItem(
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(72.dp)
+            .clip(CircleShape)
+            .background(Color.Black),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(34.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/sections/HorizontalTextSection.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/sections/HorizontalTextSection.kt
@@ -1,0 +1,50 @@
+package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.sections
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.MetaballHorizontalEdgeSection
+import com.skul.yuriy.composeplayground.util.renderEffect.alphaThreshold30PercentEffect
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+fun HorizontalTextSection(
+    modifier: Modifier = Modifier,
+) {
+    val effectMagnitude = 30.dp
+    val blurRadius = 20.dp
+    val alphaThresholdEffect = alphaThreshold30PercentEffect
+    val edgeAlpha = 0.3f
+
+    MetaballHorizontalEdgeSection(
+        modifier = modifier,
+        effectMagnitude = effectMagnitude,
+        blurRadius = blurRadius,
+        alphaThresholdEffect = alphaThresholdEffect,
+        edgeAlpha = edgeAlpha,
+    ) {
+        Text(
+            text = demoHorizontalText,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Clip,
+            style = TextStyle(
+                fontSize = HorizontalTextSize,
+                color = androidx.compose.ui.graphics.Color.Black,
+                fontWeight = FontWeight.Bold,
+            )
+        )
+    }
+}
+
+private val HorizontalTextSize = 56.sp
+
+private const val demoHorizontalText =
+    "HOME SEARCH PROFILE SETTINGS CART BUILD DONE FAVORITE HOME SEARCH PROFILE SETTINGS CART BUILD DONE FAVORITE"

--- a/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/sections/PlainIconsSection.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/feature/metaballEdgeHorizontalScroll/sections/PlainIconsSection.kt
@@ -1,0 +1,51 @@
+package com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.sections
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.MetaballHorizontalEdgeSection
+import com.skul.yuriy.composeplayground.feature.metaballEdgeHorizontalScroll.circularItemUiItems
+import com.skul.yuriy.composeplayground.util.renderEffect.alphaThreshold50PercentEffect
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+fun PlainIconsSection(
+    modifier: Modifier = Modifier,
+) {
+    val effectMagnitude = 56.dp
+    val blurRadius = 30.dp
+    val alphaThresholdEffect = alphaThreshold50PercentEffect
+    val edgeAlpha = 0.5f
+
+    MetaballHorizontalEdgeSection(
+        modifier = modifier,
+        effectMagnitude = effectMagnitude,
+        blurRadius = blurRadius,
+        alphaThresholdEffect = alphaThresholdEffect,
+        edgeAlpha = edgeAlpha,
+    ) {
+        circularItemUiItems.forEach { item ->
+            PlainIconItem(icon = item.icon)
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@Composable
+private fun PlainIconItem(
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = Color.Black,
+        modifier = modifier.size(56.dp)
+    )
+}

--- a/app/src/main/java/com/skul/yuriy/composeplayground/navigation/NavActions.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/navigation/NavActions.kt
@@ -94,6 +94,9 @@ fun NavBackStack<NavKey>.navigateToCustomAlphaBlurRadial() =
 fun NavBackStack<NavKey>.navigateToMetaballEdgeAdvanced() =
     navigate(Screens.MetaballEdgeAdvanced)
 
+fun NavBackStack<NavKey>.navigateToMetaballEdgeHorizontalScroll() =
+    navigate(Screens.MetaballEdgeHorizontalScroll)
+
 fun NavBackStack<NavKey>.navigateToMetaballPrimer() =
     navigate(Screens.MetaballBasicTextAndEdge)
 

--- a/app/src/main/java/com/skul/yuriy/composeplayground/navigation/Screens.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/navigation/Screens.kt
@@ -70,6 +70,9 @@ sealed interface Screens : NavKey {
     data object MetaballEdgeAdvanced : Screens
 
     @Serializable
+    data object MetaballEdgeHorizontalScroll : Screens
+
+    @Serializable
     data object MetaballBasicTextAndEdge : Screens
 
     @Serializable

--- a/app/src/main/java/com/skul/yuriy/composeplayground/starter/StarterScreen.kt
+++ b/app/src/main/java/com/skul/yuriy/composeplayground/starter/StarterScreen.kt
@@ -27,6 +27,7 @@ import com.skul.yuriy.composeplayground.navigation.navigateToFadingEdgesScreen
 import com.skul.yuriy.composeplayground.navigation.navigateToGooeyScreen
 import com.skul.yuriy.composeplayground.navigation.navigateToLiquidBar
 import com.skul.yuriy.composeplayground.navigation.navigateToMetaballEdgeAdvanced
+import com.skul.yuriy.composeplayground.navigation.navigateToMetaballEdgeHorizontalScroll
 import com.skul.yuriy.composeplayground.navigation.navigateToMetaballEdges
 import com.skul.yuriy.composeplayground.navigation.navigateToMetaballMath
 import com.skul.yuriy.composeplayground.navigation.navigateToMetaballPrimer
@@ -80,6 +81,10 @@ fun NavigationContent(modifier: Modifier) {
         NavigationItem(
             text = stringResource(R.string.custom_alpha_blur),
             onClick = { localNavBackStack.navigateToCustomAlphaBlur() })
+
+        NavigationItem(
+            text = stringResource(R.string.metaball_edge_horizontal_scroll),
+            onClick = { localNavBackStack.navigateToMetaballEdgeHorizontalScroll() })
 
         NavigationItem(
             text = stringResource(R.string.metaball_edge_advanced),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="metaball_primer_tab_text_melt">Text Melt</string>
     <string name="metaball_basics_prev">Previous</string>
     <string name="metaball_basics_next">Next</string>
-    <string name="metaball_edge_horizontal_scroll">Metaball Edge Horizontal Scroll</string>
+    <string name="metaball_edge_horizontal_scroll">Metaball Edge Row</string>
     <string name="metaball_edge_advanced">Metaball Edge Advanced</string>
     <string name="custom_alpha_blur">Custom Blur</string>
     <string name="custom_alpha_blur_radial">Custom Blur Radial</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="metaball_primer_tab_text_melt">Text Melt</string>
     <string name="metaball_basics_prev">Previous</string>
     <string name="metaball_basics_next">Next</string>
+    <string name="metaball_edge_horizontal_scroll">Metaball Edge Horizontal Scroll</string>
     <string name="metaball_edge_advanced">Metaball Edge Advanced</string>
     <string name="custom_alpha_blur">Custom Blur</string>
     <string name="custom_alpha_blur_radial">Custom Blur Radial</string>


### PR DESCRIPTION
  ## Summary
  This PR adds a separate `Metaball Edge Row` feature screen and stabilizes its horizontal AGSL edge effect.

  ## What was implemented
  - added a dedicated `Metaball Edge Row` screen and wired it into starter/navigation
  - extracted reusable horizontal metaball section logic for row-based edge experiments
  - added a horizontal AGSL width-based effect for left/right edge zones
  - made the feature available as a separate playground/demo screen
  - renamed the screen label to `Metaball Edge Row` so it fits in starter and top bar
  - fixed AGSL rendering artifacts by enabling `clip = true` on the graphics layer used by the custom width effect

  ## Result
  - the feature is exposed as an отдельный playground screen
  - the title now fits in one line
  - the custom horizontal edge effect behaves correctly inside layer bounds
